### PR TITLE
Load customer invoice form for customer RMA

### DIFF
--- a/rma/views/rma_view.xml
+++ b/rma/views/rma_view.xml
@@ -226,7 +226,9 @@
                         <field name="add_invoice_id"
                                domain="[('type','=','out_invoice'),'|',('commercial_partner_id','=',partner_id),
                                ('partner_id','=',partner_id), (('state','not in',['draft','cancel']))]"
-                               attrs="{'invisible':[('state','not in',['draft','to_approve'])]}"/>
+			       attrs="{'invisible':[('state','not in',['draft','to_approve'])]}"
+			       context="{'form_view_ref':'account.invoice_form'}"
+			       />
                     </group>
                     <group>
                         <group col="4">


### PR DESCRIPTION
Add context to force the customer invoice form when creating a new invoice. 

Maybe this is a good moment to add some more context, like taking the partner_id or any other info from the active RMA. Comment if you want me to do that. 